### PR TITLE
allow users to navigate from landing to index /show page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:index, :show]
+  skip_before_action :authenticate_user!, only: [:index, :show, :search]
 
   def index
     @events = Event.all


### PR DESCRIPTION
allowed users to navigate from landing to index /show page. 

**:search** action in events controller had to be set in **skip_before_action :authenticate_user!** to allow anyone to use this method and redirect you to the index page