### PR TITLE
msg button on event page only shows when user is registered

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,3 +1,5 @@
 module EventsHelper
-
+  def user_registered?(event, user)
+    event.users.exists?(user.id)
+  end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -62,13 +62,23 @@
       <% else %>
         <%= form_with url: event_event_users_path(@event), method: :post do %>
           <button type="submit" class="btn btn-dark" data-bs-toggle="modal" data-bs-target="#exampleModal">
-            Register
+            Register  <i class="fa-solid fa-user-plus"></i>
           </button>
         <% end %>
       <% end %>
+      <% if user_registered?(@event, current_user) %>
+        <%= link_to chat_path(@event), class: "btn btn-dark", style: "margin-top: 20px;" do %>
+          Messages <i class="fa-solid fa-comments"></i>
+        <% end %>
+      <% end %>
+
+
+
     </div>
   </div>
 </div>
+
+
 
 <!-- Modal -->
 <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">


### PR DESCRIPTION
The msg btn is now only visible for users that have registered for the event, otherwise it wont be available.

![image](https://github.com/user-attachments/assets/0b4b3d24-7995-41cc-94b8-a3e93a0b9218)

![image](https://github.com/user-attachments/assets/ec8d772e-9fce-40cf-b143-2b3de922be75)
