### PR TITLE
Profile page re-design - we shouldn't see other users next event or upcoming events

### DIFF
--- a/app/assets/stylesheets/components/_profile.scss
+++ b/app/assets/stylesheets/components/_profile.scss
@@ -1,6 +1,3 @@
-
-
-
 .banner-show {
   height: 200px;
 }
@@ -53,9 +50,20 @@
   border-radius: 10px;
   overflow: hidden;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  padding-top: 30px;
+  min-height: 200px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer; // Show it's clickable
+}
+.event-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
 }
 .event-card .overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   border-radius: 10px;
   padding: 20px;
 }

--- a/app/assets/stylesheets/components/_profile.scss
+++ b/app/assets/stylesheets/components/_profile.scss
@@ -28,10 +28,19 @@
   font-weight: bold;
   margin-bottom: 0.5rem;
 }
+.profile-icon-fallback {
+  background-color: #0832A8;
+  font-size: 120px;
+  color: white;
+}
 .profile-text {
   color: white;
   font-size: 1.5rem;
 }
+.profile-name {
+  font-weight: bold;
+}
+
 .profile-form {
   max-width: 500px;
   margin: 0 auto;
@@ -135,4 +144,18 @@
 .personal-info-section .btn-primary {
   background-color: #007bff;
   border-color: #007bff;
+}
+.scrollable-events {
+  max-height: calc(100vh - 40px);
+}
+
+.profile-card {
+  background-color: #93CDD4;
+  border-radius: 10px;
+}
+
+.about-label {
+  font-weight: 500;
+  opacity: 0.8;
+  color: #5E5F61;
 }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,7 +3,7 @@ class ProfilesController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update]
 
   def show
-    @user = User.find(params[:id])
+    # @user = User.find(params[:id])
     @next_event = Event.where('date >= ?', Date.today).order(:date).first
     @upcoming_events = Event.where('date >= ?', Date.today).order(:date).limit(5)
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,9 +3,13 @@ class ProfilesController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update]
 
   def show
-    # @user = User.find(params[:id])
-    @next_event = Event.where('date >= ?', Date.today).order(:date).first
-    @upcoming_events = Event.where('date >= ?', Date.today).order(:date).limit(5)
+    if @user == current_user
+      @next_event = @user.next_event
+      @upcoming_events = @user.upcoming_events
+    else
+      @next_event = nil
+      @upcoming_events = []
+    end
   end
 
   def edit

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,13 +3,8 @@ class ProfilesController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update]
 
   def show
-    if @user == current_user
-      @next_event = @user.next_event
-      @upcoming_events = @user.upcoming_events
-    else
-      @next_event = nil
-      @upcoming_events = []
-    end
+    @next_event = @user.next_event
+    @upcoming_events = @user.upcoming_events
   end
 
   def edit

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,8 +3,14 @@ class ProfilesController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update]
 
   def show
-    @next_event = @user.next_event
-    @upcoming_events = @user.upcoming_events
+    if @user == current_user
+      @next_event = @user.next_event
+      @upcoming_events = @user.upcoming_events
+    else
+      # prevents accidental data leakage, if error occours you haven't verified user on view page correctly
+      @next_event = nil
+      @upcoming_events = []
+    end
   end
 
   def edit

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,4 +19,6 @@ class Event < ApplicationRecord
   using: {
     tsearch: { prefix: true }
   }
+
+  
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,5 +20,8 @@ class Event < ApplicationRecord
     tsearch: { prefix: true }
   }
 
-  
+  # upcoming events Class Method
+  def self.upcoming
+    where(date: Date.today..).order(:date)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   def next_event
-    user_events.upcoming.first 
+    user_events.upcoming.first
   end
 
   def upcoming_events
@@ -23,6 +23,7 @@ class User < ApplicationRecord
     Event.joins(:event_users) # returns all events where user is either attendee or the creator
         .where(event_users: { user_id: id }) # checks if user is attendee
         .or(Event.where(user_id: id)) # checks if user is creator of the event
+        .distinct # removes duplicates
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,25 @@ class User < ApplicationRecord
   has_many :events, through: :event_users
   has_many :messages
   has_one_attached :photo
-  
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  def next_event
+    user_events.upcoming.first 
+  end
+
+  def upcoming_events
+    user_events.upcoming
+  end
+
+  private
+
+  def user_events
+    Event.joins(:event_users) # returns all events where user is either attendee or the creator
+        .where(event_users: { user_id: id }) # checks if user is attendee
+        .or(Event.where(user_id: id)) # checks if user is creator of the event
+  end
+
+
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,36 +1,38 @@
 <div class="container-fluid body-color min-vh-100 px-4">
   <div class="row">
     <!-- Left Column -->
-    <div class="col-md-4">
-      <div class="p-4 text-dark my-4" style="background-color: #93CDD4; border-radius: 10px;">
+    <div class="col-md-4 sticky-top">
+      <div class="p-4 text-dark my-4 profile-card">
         <div class="p-3">
           <% if @user.photo.attached? %>
             <%= image_tag @user.photo, alt: "User Avatar", class: "profile-icon" %>
           <% else %>
-            <span class="profile-icon" style="background-color: #0832A8; font-size: 120px; color: white;"><%= @user.email.split('@').first[0].upcase %></span>
+            <span class="profile-icon profile-icon-fallback">
+              <%= @user.email.split('@').first[0].upcase %>
+            </span>
           <% end %>
 
-          <h4 style="font-weight: bold;"><%= @user.first_name + " " + @user.last_name %></h4>
+          <h4 class="profile-name"><%= @user.first_name + " " + @user.last_name %></h4>
           <h6><%= @user.profile_name %></h6>
           <hr>
-          <p style="font-weight: 500; opacity: 0.8; color: #5E5F61;">About</p>
+          <p class="about-label">About</p>
           <p><%= @user.bio %></p>
           <% if @user == current_user %>
             <%= link_to edit_profile_path(@user), class: "btn-profile-edit my-2" do %>
               <i class="fa-solid fa-pen"></i> Edit profile
             <% end %>
           <% end %>
-      </div>
+        </div>
       </div>
     </div>
 
     <!-- Right Column -->
-    <div class="col-md-8">
+    <div class="col-md-8 overflow-auto py-4 scrollable-events">
       <% if @user == current_user %>
         <!-- Your Next Event Card -->
         <% if @next_event %>
           <%= link_to event_path(@next_event), class: "text-decoration-none" do %>
-            <div class="event-card my-4">
+            <div class="event-card">
               <div class="overlay" style="background-image: url(<%= event_banner_image(@next_event) %>); background-size: cover; background-position: center;">
                 <h4 class="mb-3 text-center text-white">Your Next Event</h4>
                 <h5 class="text-white"><%= @next_event.name %></h5>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,4 +1,4 @@
-<div class="container-fluid body-color min-vh-100">
+<div class="container-fluid body-color min-vh-100 px-4">
   <div class="row">
     <!-- Left Column -->
     <div class="col-md-4">
@@ -26,53 +26,43 @@
 
     <!-- Right Column -->
     <div class="col-md-8">
+      <% if @user == current_user %>
         <div class="event-card">
           <div class="overlay"
-            style="background-image: url(<%= event_banner_image(@next_event) %>); background-size: cover; background-position: center;">
+            style="background-image: url(<%= @next_event ? event_banner_image(@next_event) : 'https://picsum.photos/600/400' %>); background-size: cover; background-position: center;">
             <h4 class="mb-3 text-center text-white">Your Next Event</h4>
             <% if @next_event %>
-              <div class="mb-2 text-white"><strong>Event:</strong> <%= @next_event.name %></div>
-              <div class="mb-2 text-white"><strong>Date:</strong> <%= @next_event.date.strftime('%b %-d, %Y') %></div>
-              <div class="mb-3 text-white"><strong>Location:</strong> <%= @next_event.location %></div>
-              <div class="mt-3 text-white time-left">
-                <strong>Time Left:</strong>
-                <div id="countdown" data-event-date="<%= @next_event.date.iso8601 %>" class="countdown-timer timer-box"></div>
-              </div>
+              <h5 class="text-white"><%= @next_event.name %></h5>
+              <p class="text-white mb-1"><strong>Date:</strong> <%= @next_event.date.strftime('%b %-d, %Y') %></p>
+              <p class="text-white mb-1"><strong>Location:</strong> <%= @next_event.location %></p>
+              <p class="text-white"><%= truncate(@next_event.description, length: 100) %></p>
             <% else %>
-              <p>No upcoming events.</p>
+              <p class="text-white text-center">No upcoming events.</p>
             <% end %>
           </div>
         </div>
 
-
-
-        <div id="upcomingEventCarousel" class="carousel slide" data-bs-ride="carousel">
-          <div class="carousel-inner pt-4">
-            <% @upcoming_events.each_with_index do |event, index| %>
-              <div class="carousel-item <%= 'active' if index == 0 %>">
-                <div class="event-card" style="background-image: url(<%= event_banner_image(event) %>); background-size: cover; background-position: center;">
-                  <div class="overlay">
-                    <h4 class="mb-3 text-center text-white">Upcoming Event</h4>
-                    <div class="mb-2 text-white"><strong>Event:</strong> <%= event.name %></div>
-                    <div class="mb-2 text-white"><strong>Date:</strong> <%= event.date.strftime('%b %-d, %Y') %></div>
-                    <div class="mb-3 text-white"><strong>Location:</strong> <%= event.location %></div>
-                  </div>
+        <% if @upcoming_events.any? %>
+          <div class="mt-4">
+            <h4 class="mb-3">Your Upcoming Events</h4>
+            <% @upcoming_events.each do |event| %>
+              <div class="event-card mb-3">
+                <div class="overlay" style="background-image: url(<%= event_banner_image(event) %>); background-size: cover; background-position: center;">
+                  <h5 class="card-title text-white"><%= event.name %></h5>
+                  <p class="text-white mb-1"><strong>Date:</strong> <%= event.date.strftime('%b %-d, %Y') %></p>
+                  <p class="text-white mb-1"><strong>Location:</strong> <%= event.location %></p>
+                  <p class="text-white"><%= truncate(event.description, length: 100) %></p>
                 </div>
               </div>
             <% end %>
           </div>
-
-          <button class="carousel-control-prev" type="button" data-bs-target="#upcomingEventCarousel" data-bs-slide="prev">
-            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Previous</span>
-          </button>
-          <button class="carousel-control-next" type="button" data-bs-target="#upcomingEventCarousel" data-bs-slide="next">
-            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Next</span>
-          </button>
+        <% end %>
+      <% else %>
+        <div class="text-center py-5">
+          <h4>This user's events are private</h4>
+          <p class="text-muted">Event information is only visible to the profile owner.</p>
         </div>
-
-
-
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -27,33 +27,43 @@
     <!-- Right Column -->
     <div class="col-md-8">
       <% if @user == current_user %>
-        <div class="event-card">
-          <div class="overlay"
-            style="background-image: url(<%= @next_event ? event_banner_image(@next_event) : 'https://picsum.photos/600/400' %>); background-size: cover; background-position: center;">
-            <h4 class="mb-3 text-center text-white">Your Next Event</h4>
-            <% if @next_event %>
-              <h5 class="text-white"><%= @next_event.name %></h5>
-              <p class="text-white mb-1"><strong>Date:</strong> <%= @next_event.date.strftime('%b %-d, %Y') %></p>
-              <p class="text-white mb-1"><strong>Location:</strong> <%= @next_event.location %></p>
-              <p class="text-white"><%= truncate(@next_event.description, length: 100) %></p>
-            <% else %>
+        <!-- Your Next Event Card -->
+        <% if @next_event %>
+          <%= link_to event_path(@next_event), class: "text-decoration-none" do %>
+            <div class="event-card my-4">
+              <div class="overlay" style="background-image: url(<%= event_banner_image(@next_event) %>); background-size: cover; background-position: center;">
+                <h4 class="mb-3 text-center text-white">Your Next Event</h4>
+                <h5 class="text-white"><%= @next_event.name %></h5>
+                <p class="text-white mb-1"><strong>Date:</strong> <%= @next_event.date.strftime('%b %-d, %Y') %></p>
+                <p class="text-white mb-1"><strong>Location:</strong> <%= @next_event.location %></p>
+                <p class="text-white"><%= truncate(@next_event.description, length: 100) %></p>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="event-card my-4">
+            <div class="overlay" style="background-image: url('https://picsum.photos/600/400'); background-size: cover; background-position: center;">
+              <h4 class="mb-3 text-center text-white">Your Next Event</h4>
               <p class="text-white text-center">No upcoming events.</p>
-            <% end %>
+            </div>
           </div>
-        </div>
+        <% end %>
 
+        <!-- Upcoming Events List -->
         <% if @upcoming_events.any? %>
           <div class="mt-4">
             <h4 class="mb-3">Your Upcoming Events</h4>
             <% @upcoming_events.each do |event| %>
-              <div class="event-card mb-3">
-                <div class="overlay" style="background-image: url(<%= event_banner_image(event) %>); background-size: cover; background-position: center;">
-                  <h5 class="card-title text-white"><%= event.name %></h5>
-                  <p class="text-white mb-1"><strong>Date:</strong> <%= event.date.strftime('%b %-d, %Y') %></p>
-                  <p class="text-white mb-1"><strong>Location:</strong> <%= event.location %></p>
-                  <p class="text-white"><%= truncate(event.description, length: 100) %></p>
+              <%= link_to event_path(event), class: "text-decoration-none" do %>
+                <div class="event-card mb-4">
+                  <div class="overlay" style="background-image: url(<%= event_banner_image(event) %>); background-size: cover; background-position: center;">
+                    <h5 class="text-white"><%= event.name %></h5>
+                    <p class="text-white mb-1"><strong>Date:</strong> <%= event.date.strftime('%b %-d, %Y') %></p>
+                    <p class="text-white mb-1"><strong>Location:</strong> <%= event.location %></p>
+                    <p class="text-white"><%= truncate(event.description, length: 100) %></p>
+                  </div>
                 </div>
-              </div>
+              <% end %>
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
- Profile info now stays fixed on left while scrolling
- Events section  are now scrollable on right column

**Still need to improve the text visibility, as there might be not enough contrast if image is too white**

https://github.com/user-attachments/assets/3ae8f6c8-9b96-4172-a1eb-2e920d9c4da4

- Made event list private for profile visitors
<img width="1792" alt="Screenshot 2025-06-05 at 00 29 47" src="https://github.com/user-attachments/assets/5a6cae58-29a0-44cc-98f0-ce5d8c59db92" />

- Old design for comparison 
<img width="1792" alt="Screenshot 2025-06-05 at 00 37 07" src="https://github.com/user-attachments/assets/f71af3dc-ebf1-40a7-a58d-4989165d73d6" />
